### PR TITLE
Redis bind configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,15 @@
 ---
+sudo: required
 language: python
-python: "2.7"
 
-# Use the new container infrastructure
-sudo: false
-
-# Install ansible
-addons:
-  apt:
-    packages:
-    - python-pip
+services:
+  - docker
 
 install:
-  # Install ansible
-  - pip install ansible
-
-  # Check ansible version
-  - ansible --version
-
-  # Create ansible.cfg with correct roles_path
-  - printf '[defaults]\nroles_path=../' >ansible.cfg
+  - pip install ome-ansible-molecule-dependencies
 
 script:
-  # Basic role syntax check
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  - molecule test
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,13 @@ Redis
 
 Install Redis.
 
-TODO: Add configuration options.
+
+Role Variables
+--------------
+
+All variables are optional.
+- `redis_listen`: String containing interfaces to bind to, default `127.0.0.1`
+
 
 Author Information
 ------------------

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+# Handlers for redis
+
+- name: restart redis
+  become: yes
+  service:
+    name: redis
+    state: restarted

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,0 +1,29 @@
+---
+dependency: []
+
+# Default driver
+driver:
+  name: docker
+
+vagrant:
+  platforms:
+    - name: centos7
+      box: centos/7
+  providers:
+    - name: virtualbox
+      type: virtualbox
+      options:
+        memory: 512
+        cpus: 1
+  instances:
+    - name: redis
+
+docker:
+  containers:
+  - name: redis
+    image: centos/systemd
+    image_version: latest
+    privileged: yes
+
+verifier:
+  name: testinfra

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  roles:
+    - role: ansible-role-redis
+      redis_listen: 0.0.0.0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,16 @@
     name: redis
     state: present
 
+- name: configure redis
+  become: yes
+  lineinfile:
+    dest: /etc/redis.conf
+    line: "bind {{ redis_listen | default('127.0.0.1') }}"
+    regexp: "^bind\\s.*"
+    state: present
+  notify:
+    - restart redis
+
 - name: set redis to start on startup
   become: yes
   service:

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-  - role: ansible-role-redis

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,0 +1,13 @@
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('all')
+
+
+def test_service_running_and_enabled(Service):
+    assert Service('redis').is_running
+    assert Service('redis').is_enabled
+
+
+def test_redis_config(File):
+    assert File('/etc/redis.conf').contains('bind 0.0.0.0')


### PR DESCRIPTION
Allow redis to listen on external interfaces, needed when running a cluster of OMERO.web with shared session storage.

Tag: new feature, `1.1.0`